### PR TITLE
docs(README): 修复错误的git clone命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ SMTP_FROM_NAME=AI Goofish Monitor
 
 1. **克隆项目**
 ```bash
-git clone https://github.com/ddCat-main/goofish-ai.git
+git clone https://github.com/ddCat-main/ai-goofish.git
 cd goofish-ai
 ```
 


### PR DESCRIPTION
原命令：git clone https://github.com/ddCat-main/goofish-ai.git 
修复后：git clone https://github.com/ddCat-main/ai-goofish.git